### PR TITLE
Change menu action to match that defined in pandoc.coffee

### DIFF
--- a/menus/pandoc.cson
+++ b/menus/pandoc.cson
@@ -9,7 +9,7 @@
     'submenu': [
       'label': 'pandoc'
       'submenu': [
-        { 'label': 'Preview', 'command': 'pandoc:show' }
+        { 'label': 'Preview', 'command': 'pandoc-preview:show' }
       ]
     ]
   }


### PR DESCRIPTION
pandoc.coffee defines the action 'pandoc-preview:show' so 'pandoc:show'
does nothing. This change switches to use the defined action.